### PR TITLE
Add brief installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # GDNative Based Git Plugin for Godot Version Control Editor Plugin
 Implements the proxy end-points for the `EditorVCSInterface` API in the Godot Engine Editor. Uses [libgit2](https://libgit2.org) at its backend to simulate Git in code.
 
+## Installation Instructions
+
+ 1. Plugin binary releases for Linux & Windows are here: <https://github.com/godotengine/godot-git-plugin/releases>
+ 2. Installation instructions are here: <https://godotengine.org/article/gsoc-2019-progress-report-3#vcs-integration>
+
 ## Build Instructions
 
 ### Windows


### PR DESCRIPTION
Primarily so people realise building from source isn't required for Windows/Linux.

(via https://github.com/godotengine/godot-docs/issues/2838)