### PR TITLE
AppVeyor: Fix path to vcvars64, use SCons 3.1.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ environment:
 
 os: Visual Studio 2019
 
+build: off
+
 configuration:
   - release
   - debug

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,5 +16,5 @@ install:
   - curl -LO https://downloads.sourceforge.net/project/scons/scons-local/3.1.2/scons-local-3.1.2.zip
   - unzip scons-local-3.1.2.zip
   - .\build_libs.bat %configuration%
-  - dir
-  - scons platform=windows target=%configuration% -j2
+  - cd ..
+  - ..\scons.bat platform=windows target=%configuration% -j2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
-
-# environment:
-#   matrix:
-#     - vs_version: 16
+environment:
+  matrix:
+    - vs_version: 16
 
 os: Visual Studio 2019
 
@@ -13,8 +12,9 @@ platform:
   - x64
 
 install:
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-  - curl -LO https://downloads.sourceforge.net/project/scons/scons-local/3.0.5/scons-local-3.0.5.zip
-  - unzip scons-local-3.0.5.zip
-  - ./build_libs.bat %configuration%
-  - scons platform=windows target=%configuration% -j6
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - curl -LO https://downloads.sourceforge.net/project/scons/scons-local/3.1.2/scons-local-3.1.2.zip
+  - unzip scons-local-3.1.2.zip
+  - .\build_libs.bat %configuration%
+  - dir
+  - scons platform=windows target=%configuration% -j2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,4 +17,4 @@ install:
   - unzip scons-local-3.1.2.zip
   - .\build_libs.bat %configuration%
   - cd ..
-  - ..\scons.bat platform=windows target=%configuration% -j2
+  - .\scons.bat platform=windows target=%configuration% -j2

--- a/build_libs.bat
+++ b/build_libs.bat
@@ -11,5 +11,5 @@ cd ../../../../
 copy godot-git-plugin\thirdparty\libgit2\build\%1\git2.lib demo\bin\win64\
 
 cd godot-cpp\
-scons platform=windows target=%1 generate_bindings=yes bits=64
+..\scons.bat platform=windows target=%1 generate_bindings=yes bits=64
 cd ..


### PR DESCRIPTION
Do not merge until we know that it fixes it.