### PR TITLE
Changes for new version control system

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -87,7 +87,7 @@ cpp_library += '.' + str(bits)
 # make sure our binding library properly includes
 env.Append(CPPPATH=['.', godot_headers_path, cpp_bindings_path + 'include/', cpp_bindings_path + 'include/core/', cpp_bindings_path + 'include/gen/'])
 env.Append(LIBPATH=[cpp_bindings_path + 'bin/', libgit2_lib_path])
-env.Append(LIBS=[cpp_library, 'git2'])
+env.Append(LIBS=[cpp_library, 'ssl', 'crypto', 'ssh2', 'git2'])
 
 # tweak this if you want to use different folders, or more folders, to store your source code in.
 env.Append(CPPPATH=['godot-git-plugin/src/', libgit2_include_path])

--- a/build_libs.sh
+++ b/build_libs.sh
@@ -5,12 +5,11 @@ cd godot-git-plugin/thirdparty/libgit2/
 mkdir build
 cd build/
 rm CMakeCache.txt
-cmake .. -DBUILD_SHARED_LIBS=OFF -DBUILD_CLAR=OFF -DBUILD_EXAMPLES=OFF -DUSE_SSH=OFF -DUSE_HTTPS=OFF -DUSE_BUNDLED_ZLIB=ON
+cmake .. -DBUILD_SHARED_LIBS=OFF -DBUILD_CLAR=OFF -DBUILD_EXAMPLES=OFF -DUSE_SSH=ON -DUSE_HTTPS=ON -DUSE_BUNDLED_ZLIB=ON -DREGEX_BACKEND=builtin
 cmake --build .
 cd ../../../../
 mv godot-git-plugin/thirdparty/libgit2/build/libgit2.a demo/bin/x11/libgit2.a
 
 cd godot-cpp/;
-apt-get install scons
 scons platform=linux target=$1 generate_bindings=yes bits=64;
 cd ..

--- a/godot-git-plugin/src/git_api.cpp
+++ b/godot-git-plugin/src/git_api.cpp
@@ -2,8 +2,6 @@
 
 namespace godot {
 
-GitAPI *GitAPI::singleton = NULL;
-
 void GitAPI::_register_methods() {
 
 	register_method("_process", &GitAPI::_process);
@@ -17,14 +15,30 @@ void GitAPI::_register_methods() {
 	register_method("_initialize", &GitAPI::_initialize);
 	register_method("_shut_down", &GitAPI::_shut_down);
 	register_method("_stage_file", &GitAPI::_stage_file);
+	register_method("_discard_file", &GitAPI::_discard_file);
 	register_method("_unstage_file", &GitAPI::_unstage_file);
+	register_method("_get_previous_commits", &GitAPI::_get_previous_commits);
+	register_method("_get_branch_list", &GitAPI::_get_branch_list);
+	register_method("_checkout_branch", &GitAPI::_checkout_branch);
+	register_method("_fetch", &GitAPI::_fetch);
+	register_method("_pull", &GitAPI::_pull);
+	register_method("_push", &GitAPI::_push);
+	register_method("_set_up_credentials", &GitAPI::_set_up_credentials);
+}
+
+void GitAPI::_discard_file(String p_file_path) {
+
+	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
+	char *paths[] = { p_file_path.alloc_c_string() };
+	opts.paths = { paths, 1 };
+	opts.checkout_strategy = GIT_CHECKOUT_FORCE;
+	GIT2_CALL(git_checkout_index(repo, NULL, &opts), "Cannot checkout a file");
 }
 
 void GitAPI::_commit(const String p_msg) {
 
 	if (!can_commit) {
-
-		godot::Godot::print("Git API cannot commit. Check previous errors.");
+		godot::Godot::print("Git API: Cannot commit. Check previous errors.");
 		return;
 	}
 
@@ -34,43 +48,53 @@ void GitAPI::_commit(const String p_msg) {
 	git_index *repo_index;
 	git_commit *parent_commit;
 
-	GIT2_CALL(git_repository_index(&repo_index, repo), "Could not get repository index", NULL);
-	for (int i = 0; i < staged_files.size(); i++) {
+	GIT2_CALL(git_repository_index(&repo_index, repo), "Could not get repository index");
+	GIT2_CALL(git_index_write_tree(&tree_id, repo_index), "Could not write index to tree");
+	GIT2_CALL(git_index_write(repo_index), "Could not write index to disk");
 
-		String file_path = staged_files[i];
-		File *file = File::_new();
-		if (file->file_exists(file_path)) {
+	GIT2_CALL(git_tree_lookup(&tree, repo, &tree_id), "Could not lookup tree from ID");
+	GIT2_CALL(git_signature_default(&default_sign, repo), "Could not get default signature");
 
-			GIT2_CALL(git_index_add_bypath(repo_index, file_path.alloc_c_string()), "Could not add file by path", NULL);
-		} else {
+	GIT2_CALL(git_reference_name_to_id(&parent_commit_id, repo, "HEAD"), "Could not get parent ID");
+	GIT2_CALL(git_commit_lookup(&parent_commit, repo, &parent_commit_id), "Could not lookup parent commit data");
 
-			GIT2_CALL(git_index_remove_bypath(repo_index, file_path.alloc_c_string()), "Could not add file by path", NULL);
-		}
+	if (!has_merge) {
+
+		GIT2_CALL(
+				git_commit_create_v(
+						&new_commit_id,
+						repo,
+						"HEAD",
+						default_sign,
+						default_sign,
+						"UTF-8",
+						p_msg.alloc_c_string(),
+						tree,
+						1,
+						parent_commit),
+				"Could not create commit");
+	} else {
+		git_commit *fetchhead_commit;
+		git_commit_lookup(&fetchhead_commit, repo, &pull_merge_oid);
+
+		GIT2_CALL(
+				git_commit_create_v(
+						&new_commit_id,
+						repo,
+						"HEAD",
+						default_sign,
+						default_sign,
+						"UTF-8",
+						p_msg.alloc_c_string(),
+						tree,
+						2,
+						parent_commit,
+						fetchhead_commit),
+				"Could not create commit");
+		has_merge = false;
+		git_commit_free(fetchhead_commit);
+		git_repository_state_cleanup(repo);
 	}
-	GIT2_CALL(git_index_write_tree(&tree_id, repo_index), "Could not write index to tree", NULL);
-	GIT2_CALL(git_index_write(repo_index), "Could not write index to disk", NULL);
-	GIT2_CALL(git_signature_default(&default_sign, repo), "Could not get default signature", NULL);
-	GIT2_CALL(git_tree_lookup(&tree, repo, &tree_id), "Could not lookup tree from ID", NULL);
-
-	GIT2_CALL(git_reference_name_to_id(&parent_commit_id, repo, "HEAD"), "Could not get parent ID", NULL);
-	GIT2_CALL(git_commit_lookup(&parent_commit, repo, &parent_commit_id), "Could not lookup parent commit data", NULL);
-
-	GIT2_CALL(
-			git_commit_create_v(
-					&new_commit_id,
-					repo,
-					"HEAD",
-					default_sign,
-					default_sign,
-					"UTF-8",
-					p_msg.alloc_c_string(),
-					tree,
-					1,
-					parent_commit),
-			"Could not create commit",
-			NULL);
-
-	staged_files.clear();
 
 	git_index_free(repo_index);
 	git_signature_free(default_sign);
@@ -79,19 +103,29 @@ void GitAPI::_commit(const String p_msg) {
 }
 
 void GitAPI::_stage_file(const String p_file_path) {
+	git_index *index;
+	char *paths[] = { p_file_path.alloc_c_string() };
+	git_strarray array = { paths, 1 };
 
-	if (staged_files.find(p_file_path) == -1) {
+	GIT2_CALL(git_repository_index(&index, repo), "Could not get repository index");
+	GIT2_CALL(git_index_add_all(index, &array, GIT_INDEX_ADD_DEFAULT | GIT_INDEX_ADD_DISABLE_PATHSPEC_MATCH, NULL, NULL), "Could not add a file");
 
-		staged_files.push_back(p_file_path);
-	}
+	GIT2_CALL(git_index_write(index), "Could not write changes to disk");
+	git_index_free(index);
 }
 
 void GitAPI::_unstage_file(const String p_file_path) {
 
-	if (staged_files.find(p_file_path) != -1) {
+	char *paths[] = { p_file_path.alloc_c_string() };
+	git_strarray array = { paths, 1 };
 
-		staged_files.erase(p_file_path);
-	}
+	git_reference *head;
+	git_object *head_commit;
+
+	git_repository_head(&head, repo);
+	git_reference_peel(&head_commit, head, GIT_OBJ_COMMIT);
+
+	git_reset_default(repo, head_commit, &array);
 }
 
 void GitAPI::create_gitignore_and_gitattributes() {
@@ -149,25 +183,16 @@ bool GitAPI::create_initial_commit() {
 		godot::Godot::print_error("Unable to create a commit signature. Perhaps 'user.name' and 'user.email' are not set. Set default user name and user email by `git config` and initialize again", __func__, __FILE__, __LINE__);
 		return false;
 	}
-	GIT2_CALL(git_repository_index(&repo_index, repo), "Could not get repository index", NULL);
-	GIT2_CALL(git_index_write_tree(&tree_id, repo_index), "Could not create intial commit", NULL);
+	GIT2_CALL_R(git_repository_index(&repo_index, repo), "Could not get repository index", false);
+	GIT2_CALL_R(git_index_write_tree(&tree_id, repo_index), "Could not create intial commit", false);
 
-	GIT2_CALL(git_tree_lookup(&tree, repo, &tree_id), "Could not create intial commit", NULL);
-	GIT2_CALL(
-			git_commit_create_v(
-					&commit_id,
-					repo,
-					"HEAD",
-					sig,
-					sig,
-					NULL,
-					"Initial commit",
-					tree,
-					0),
+	GIT2_CALL_R(git_tree_lookup(&tree, repo, &tree_id), "Could not create intial commit", false);
+	GIT2_CALL_R(
+			git_commit_create_v(&commit_id, repo, "HEAD", sig, sig, NULL, "Initial commit", tree, 0),
 			"Could not create the initial commit",
-			NULL);
+			false);
 
-	GIT2_CALL(git_index_write(repo_index), "Could not write index to disk", NULL);
+	GIT2_CALL_R(git_index_write(repo_index), "Could not write index to disk", false);
 	git_index_free(repo_index);
 	git_tree_free(tree);
 	git_signature_free(sig);
@@ -182,16 +207,22 @@ bool GitAPI::_is_vcs_initialized() {
 
 Dictionary GitAPI::_get_modified_files_data() {
 
+	Dictionary diff;
+	Dictionary index; // Schema is <file_path, status>
+	Dictionary wt; // Schema is <file_path, status>
+	diff["index"] = index;
+	diff["wt"] = wt;
+
 	git_status_options opts = GIT_STATUS_OPTIONS_INIT;
 	opts.show = GIT_STATUS_SHOW_INDEX_AND_WORKDIR;
 	opts.flags = GIT_STATUS_OPT_EXCLUDE_SUBMODULES;
 	opts.flags |= GIT_STATUS_OPT_INCLUDE_UNTRACKED | GIT_STATUS_OPT_RENAMES_HEAD_TO_INDEX | GIT_STATUS_OPT_SORT_CASE_SENSITIVELY | GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS;
 
 	git_status_list *statuses = NULL;
-	GIT2_CALL(git_status_list_new(&statuses, repo, &opts), "Could not get status information from repository", NULL);
+	GIT2_CALL_R(git_status_list_new(&statuses, repo, &opts), "Could not get status information from repository", diff);
 
-	Dictionary diff; // Schema is <file_path, status>
 	size_t count = git_status_list_entrycount(statuses);
+
 	for (size_t i = 0; i < count; ++i) {
 
 		const git_status_entry *entry = git_status_byindex(statuses, i);
@@ -203,57 +234,256 @@ Dictionary GitAPI::_get_modified_files_data() {
 
 			path = entry->head_to_index->new_file.path;
 		}
-		switch (entry->status) {
 
-			case GIT_STATUS_INDEX_NEW:
-			case GIT_STATUS_WT_NEW: {
+		static Dictionary map_changes;
+		map_changes[GIT_STATUS_WT_NEW] = 0;
+		map_changes[GIT_STATUS_INDEX_NEW] = 0;
+		map_changes[GIT_STATUS_WT_MODIFIED] = 1;
+		map_changes[GIT_STATUS_INDEX_MODIFIED] = 1;
+		map_changes[GIT_STATUS_WT_RENAMED] = 2;
+		map_changes[GIT_STATUS_INDEX_RENAMED] = 2;
+		map_changes[GIT_STATUS_WT_DELETED] = 3;
+		map_changes[GIT_STATUS_INDEX_DELETED] = 3;
+		map_changes[GIT_STATUS_WT_TYPECHANGE] = 4;
+		map_changes[GIT_STATUS_INDEX_TYPECHANGE] = 4;
+		map_changes[GIT_STATUS_CONFLICTED] = 5;
 
-				diff[path] = 0;
-			} break;
-			case GIT_STATUS_INDEX_MODIFIED:
-			case GIT_STATUS_WT_MODIFIED: {
+		const static int git_status_wt = GIT_STATUS_WT_NEW | GIT_STATUS_WT_MODIFIED | GIT_STATUS_WT_DELETED | GIT_STATUS_WT_TYPECHANGE | GIT_STATUS_WT_RENAMED | GIT_STATUS_CONFLICTED;
+		const static int git_status_index = GIT_STATUS_INDEX_NEW | GIT_STATUS_INDEX_MODIFIED | GIT_STATUS_INDEX_DELETED | GIT_STATUS_INDEX_RENAMED | GIT_STATUS_INDEX_TYPECHANGE;
 
-				diff[path] = 1;
-			} break;
-			case GIT_STATUS_INDEX_RENAMED:
-			case GIT_STATUS_WT_RENAMED: {
+		if (entry->status & git_status_wt) {
+			wt[path] = map_changes[entry->status & git_status_wt];
+		}
 
-				diff[path] = 2;
-			} break;
-			case GIT_STATUS_INDEX_DELETED:
-			case GIT_STATUS_WT_DELETED: {
-
-				diff[path] = 3;
-			} break;
-			case GIT_STATUS_INDEX_TYPECHANGE:
-			case GIT_STATUS_WT_TYPECHANGE: {
-
-				diff[path] = 4;
-			} break;
+		if (entry->status & git_status_index) {
+			if (entry->status == GIT_STATUS_INDEX_RENAMED) {
+				String old_path = entry->head_to_index->old_file.path;
+				index[old_path] = map_changes[GIT_STATUS_INDEX_DELETED];
+				index[path] = map_changes[GIT_STATUS_INDEX_NEW];
+				continue;
+			}
+			index[path] = map_changes[entry->status & git_status_index];
 		}
 	}
 
 	git_status_list_free(statuses);
-
 	return diff;
+}
+
+Array GitAPI::_get_branch_list() {
+	git_branch_iterator *it;
+	git_reference *ref;
+	git_branch_t type;
+	Array branch_names;
+	git_branch_iterator_new(&it, repo, GIT_BRANCH_LOCAL);
+
+	branch_names.push_back(String()); // Leave Space for current branch
+
+	while (git_branch_next(&ref, &type, it) != GIT_ITEROVER) {
+		const char *name;
+		git_branch_name(&name, ref);
+		if (git_branch_is_head(ref)) {
+			branch_names[0] = String(name);
+		} else {
+			branch_names.push_back(String(name));
+		}
+		git_reference_free(ref);
+	}
+	git_branch_iterator_free(it);
+
+	return branch_names;
+}
+
+const char *GitAPI::_get_current_branch_name(bool full_ref) {
+	git_reference *head, *branch;
+	git_repository_head(&head, repo);
+	git_reference_resolve(&branch, head);
+	const char *branch_name;
+	if (full_ref) {
+		branch_name = git_reference_name(branch);
+	} else {
+		git_branch_name(&branch_name, branch);
+	}
+
+	git_reference_free(head);
+	git_reference_free(branch);
+	return branch_name;
+}
+
+Array GitAPI::_get_previous_commits() {
+
+	Array commits;
+	git_revwalk *walker;
+	git_commit *commit;
+	const git_signature *sig;
+	git_oid oid;
+
+	git_revwalk_new(&walker, repo);
+	git_revwalk_sorting(walker, GIT_SORT_TIME);
+	git_revwalk_push_head(walker);
+
+	for (int i = 0; !git_revwalk_next(&oid, walker) && i <= max_commit_fetch; i++) {
+
+		GIT2_CALL_R(git_commit_lookup(&commit, repo, &oid), "Failed to lookup the commit", Array());
+
+		sig = git_commit_author(commit);
+
+		Dictionary commit_info;
+		commit_info["message"] = String(git_commit_message(commit));
+		commit_info["author"] = String(sig->name);
+		commit_info["when"] = (int64_t)sig->when.time + (int64_t)(sig->when.offset * 60); // Epoch time in seconds
+		commits.push_back(commit_info);
+		git_commit_free(commit);
+	}
+
+	git_revwalk_free(walker);
+
+	return commits;
+}
+
+void GitAPI::_fetch() {
+
+	Godot::print("Git API: Performing fetch...");
+	GIT2_CALL(git_remote_connect(remote, GIT_DIRECTION_FETCH, &remote_cbs, NULL, NULL), "Can not connect to remote \"" + String(remote_name) + "\"");
+
+	git_fetch_options opts = GIT_FETCH_OPTIONS_INIT;
+	opts.callbacks = remote_cbs;
+	GIT2_CALL(git_remote_fetch(remote, NULL, &opts, "fetch"), "Can not fetch data from remote");
+}
+
+void GitAPI::_pull() {
+	Godot::print("Git API: Performing pull...");
+
+	GIT2_CALL(git_remote_connect(remote, GIT_DIRECTION_FETCH, &remote_cbs, NULL, NULL), "Can not connect to remote \"" + String(remote_name) + "\"");
+
+	git_fetch_options fetch_opts = GIT_FETCH_OPTIONS_INIT;
+	fetch_opts.callbacks = remote_cbs;
+
+	const char *branch_name = _get_current_branch_name(false);
+	// There is no way to get remote branch name from current branch name with libgit2
+	String ref_name = "refs/heads/" + String(branch_name) + ":refs/remotes/" + String(remote_name) + "/" + String(branch_name);
+	char *ref[] = { ref_name.alloc_c_string() };
+	git_strarray refspec = { ref, 1 };
+
+	GIT2_CALL(git_remote_fetch(remote, &refspec, &fetch_opts, "pull"), "Can not fetch data from remote");
+	GIT2_CALL(git_repository_fetchhead_foreach(repo, fetchhead_foreach_cb, &pull_merge_oid), "Can not read \"FETCH_HEAD\" file");
+
+	if (!&pull_merge_oid) {
+		return;
+	}
+
+	git_annotated_commit *fetchhead_annotated_commit;
+	GIT2_CALL(git_annotated_commit_lookup(&fetchhead_annotated_commit, repo, &pull_merge_oid), "Can not get merge commit");
+
+	const git_annotated_commit *merge_heads[] = { fetchhead_annotated_commit };
+
+	git_merge_analysis_t merge_analysis;
+	git_merge_preference_t preference = GIT_MERGE_PREFERENCE_NONE;
+	GIT2_CALL(git_merge_analysis(&merge_analysis, &preference, repo, merge_heads, 1), "Merge analysis failed");
+
+	if (merge_analysis & GIT_MERGE_ANALYSIS_FASTFORWARD) {
+		git_checkout_options ff_checkout_options = GIT_CHECKOUT_OPTIONS_INIT;
+		git_reference *target_ref;
+		git_reference *new_target_ref;
+		git_object *target = NULL;
+		int err = 0;
+
+		GIT2_CALL(git_repository_head(&target_ref, repo), "Failed to get HEAD reference");
+		GIT2_CALL(git_object_lookup(&target, repo, &pull_merge_oid, GIT_OBJECT_COMMIT), "failed to lookup OID " + String(git_oid_tostr_s(&pull_merge_oid)));
+
+		ff_checkout_options.checkout_strategy = GIT_CHECKOUT_SAFE;
+		GIT2_CALL(git_checkout_tree(repo, target, &ff_checkout_options), "Failed to checkout HEAD reference");
+
+		GIT2_CALL(git_reference_set_target(&new_target_ref, target_ref, &pull_merge_oid, NULL), "Failed to move HEAD reference");
+
+		git_reference_free(target_ref);
+		git_reference_free(new_target_ref);
+		Godot::print("Git API: Fast Forwrded");
+		git_repository_state_cleanup(repo);
+	} else if (merge_analysis & GIT_MERGE_ANALYSIS_NORMAL) {
+		git_merge_options merge_opts = GIT_MERGE_OPTIONS_INIT;
+		git_checkout_options checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
+
+		merge_opts.file_favor = GIT_MERGE_FILE_FAVOR_NORMAL;
+		merge_opts.file_flags = (GIT_MERGE_FILE_STYLE_DIFF3 | GIT_MERGE_FILE_DIFF_MINIMAL);
+		checkout_opts.checkout_strategy = (GIT_CHECKOUT_SAFE | GIT_CHECKOUT_ALLOW_CONFLICTS | GIT_CHECKOUT_CONFLICT_STYLE_DIFF3);
+		GIT2_CALL(git_merge(repo, merge_heads, 1, &merge_opts, &checkout_opts), "Merge Faild");
+
+		git_index *index;
+		git_repository_index(&index, repo);
+
+		if (git_index_has_conflicts(index)) {
+			Godot::print("Git API: Index has conflicts, Solve conflicts and make a merge commit.");
+		} else {
+			Godot::print("Git API: Change are staged, make a merge commit.");
+		}
+
+		git_index_free(index);
+		has_merge = true;
+
+	} else if (merge_analysis & GIT_MERGE_ANALYSIS_UP_TO_DATE) {
+		Godot::print("Git API: Already up to date");
+		git_repository_state_cleanup(repo);
+	} else {
+		Godot::print("Git API: Can not merge");
+	}
+
+	git_annotated_commit_free(fetchhead_annotated_commit);
+}
+
+void GitAPI::_push() {
+	Godot::print("Git API: Performing push...");
+
+	GIT2_CALL(git_remote_connect(remote, GIT_DIRECTION_PUSH, &remote_cbs, NULL, NULL), "Can not connect to remote \"" + String(remote_name) + "\"");
+
+	git_push_options push_opts = GIT_PUSH_OPTIONS_INIT;
+	push_opts.callbacks = remote_cbs;
+
+	String branch_name = String(_get_current_branch_name(true));
+	char *ref[] = { branch_name.alloc_c_string() };
+	git_strarray refspecs = { ref, 1 };
+
+	GIT2_CALL(git_remote_upload(remote, &refspecs, &push_opts), "Faild to push");
+}
+
+void GitAPI::_set_up_credentials(String p_username, String p_password) {
+	creds.username = p_username.alloc_c_string();
+	creds.password = p_password.alloc_c_string();
+}
+
+bool GitAPI::_checkout_branch(String p_branch_name) {
+	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
+	opts.checkout_strategy = GIT_CHECKOUT_SAFE;
+	git_reference *ref, *branch;
+	git_object *treeish;
+
+	GIT2_CALL_R(git_branch_lookup(&branch, repo, p_branch_name.alloc_c_string(), GIT_BRANCH_LOCAL), "", false);
+	const char *branch_ref_name = git_reference_name(branch);
+
+	GIT2_CALL_R(git_revparse_single(&treeish, repo, p_branch_name.alloc_c_string()), "", false);
+	GIT2_CALL_R(git_checkout_tree(repo, treeish, &opts), "", false);
+	GIT2_CALL_R(git_repository_set_head(repo, branch_ref_name), "", false);
+
+	return true;
 }
 
 Array GitAPI::_get_file_diff(const String file_path) {
 
 	git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
 	git_diff *diff;
-	char *pathspec = file_path.alloc_c_string();
 
 	opts.context_lines = 3;
 	opts.interhunk_lines = 0;
 	opts.flags = GIT_DIFF_DISABLE_PATHSPEC_MATCH | GIT_DIFF_INCLUDE_UNTRACKED;
+
+	char *pathspec = file_path.alloc_c_string();
 	opts.pathspec.strings = &pathspec;
 	opts.pathspec.count = 1;
 
-	GIT2_CALL(git_diff_index_to_workdir(&diff, repo, NULL, &opts), "Could not create diff for index from working directory", NULL);
+	GIT2_CALL_R(git_diff_index_to_workdir(&diff, repo, NULL, &opts), "Could not create diff for index from working directory", Array());
 
 	diff_contents.clear();
-	GIT2_CALL(git_diff_print(diff, GIT_DIFF_FORMAT_PATCH, diff_line_callback_function, NULL), "Call to diff handler provided unsuccessful", NULL);
+	GIT2_CALL_R(git_diff_print(diff, GIT_DIFF_FORMAT_PATCH, diff_line_callback_function, &diff_contents), "Call to diff handler provided unsuccessful", Array());
 
 	git_diff_free(diff);
 
@@ -274,8 +504,6 @@ bool GitAPI::_initialize(const String p_project_root_path) {
 
 	ERR_FAIL_COND_V(p_project_root_path == "", false);
 
-	singleton = this;
-
 	int init = git_libgit2_init();
 	if (init > 1) {
 
@@ -288,7 +516,7 @@ bool GitAPI::_initialize(const String p_project_root_path) {
 	}
 
 	can_commit = true;
-	GIT2_CALL(git_repository_init(&repo, p_project_root_path.alloc_c_string(), 0), "Could not initialize repository", NULL);
+	GIT2_CALL_R(git_repository_init(&repo, p_project_root_path.alloc_c_string(), 0), "Could not initialize repository", false);
 	if (git_repository_head_unborn(repo) == 1) {
 
 		create_gitignore_and_gitattributes();
@@ -299,7 +527,18 @@ bool GitAPI::_initialize(const String p_project_root_path) {
 		}
 	}
 
-	GIT2_CALL(git_repository_open(&repo, p_project_root_path.alloc_c_string()), "Could not open repository", NULL);
+	GIT2_CALL_R(git_repository_open(&repo, p_project_root_path.alloc_c_string()), "Could not open repository", false);
+	GIT2_CALL_R(git_remote_lookup(&remote, repo, remote_name), "Can not find remote \"" + String(remote_name) + "\" ", true);
+
+	remote_cbs = GIT_REMOTE_CALLBACKS_INIT;
+	remote_cbs.credentials = credentials_cb;
+	remote_cbs.update_tips = &update_cb;
+	remote_cbs.sideband_progress = &progress_cb;
+	remote_cbs.transfer_progress = transfer_progress_cb;
+	remote_cbs.payload = &creds;
+	remote_cbs.push_transfer_progress = push_transfer_progress_cb;
+	remote_cbs.push_update_reference = push_update_reference_cb;
+
 	is_initialized = true;
 
 	return is_initialized;
@@ -308,8 +547,8 @@ bool GitAPI::_initialize(const String p_project_root_path) {
 bool GitAPI::_shut_down() {
 
 	git_repository_free(repo);
-
-	GIT2_CALL(git_libgit2_shutdown(), "Could not shutdown Git Addon", NULL);
+	git_remote_free(remote);
+	GIT2_CALL_R(git_libgit2_shutdown(), "Could not shutdown Git Addon", false);
 
 	return true;
 }

--- a/godot-git-plugin/src/git_api.h
+++ b/godot-git-plugin/src/git_api.h
@@ -41,7 +41,7 @@ class GitAPI : public EditorVCSInterface {
 
 	void _commit(const String p_msg);
 	bool _is_vcs_initialized();
-	Dictionary _get_modified_files_data();
+	Array _get_modified_files_data();
 	Array _get_file_diff(const String file_path, int area);
 	String _get_project_name();
 	String _get_vcs_name();

--- a/godot-git-plugin/src/git_api.h
+++ b/godot-git-plugin/src/git_api.h
@@ -36,14 +36,13 @@ class GitAPI : public EditorVCSInterface {
 	git_remote_callbacks remote_cbs;
 
 	bool has_merge = false;
-	Array diff_contents;
 	git_oid pull_merge_oid;
 	Credentials creds;
 
 	void _commit(const String p_msg);
 	bool _is_vcs_initialized();
 	Dictionary _get_modified_files_data();
-	Array _get_file_diff(const String file_path);
+	Array _get_file_diff(const String file_path, int area);
 	String _get_project_name();
 	String _get_vcs_name();
 	bool _initialize(const String p_project_root_path);
@@ -60,6 +59,7 @@ class GitAPI : public EditorVCSInterface {
 	void _push();
 	const char *_get_current_branch_name(bool full_ref);
 	void _set_up_credentials(String p_username, String p_password);
+	Array _parse_diff(git_diff *diff);
 
 public:
 	static void _register_methods();

--- a/godot-git-plugin/src/git_api.h
+++ b/godot-git-plugin/src/git_api.h
@@ -62,6 +62,8 @@ class GitAPI : public EditorVCSInterface {
 	Array _parse_diff(git_diff *diff);
 	Array _get_line_diff(String p_file_path, String p_text);
 
+	bool check_errors(int error, String message, String function, String file, int line);
+
 public:
 	static void _register_methods();
 

--- a/godot-git-plugin/src/git_api.h
+++ b/godot-git-plugin/src/git_api.h
@@ -60,6 +60,7 @@ class GitAPI : public EditorVCSInterface {
 	const char *_get_current_branch_name(bool full_ref);
 	void _set_up_credentials(String p_username, String p_password);
 	Array _parse_diff(git_diff *diff);
+	Array _get_line_diff(String p_file_path, String p_text);
 
 public:
 	static void _register_methods();

--- a/godot-git-plugin/src/git_api.h
+++ b/godot-git-plugin/src/git_api.h
@@ -1,16 +1,17 @@
 #ifndef GIT_API_H
 #define GIT_API_H
 
-#include <Godot.hpp>
 #include <Button.hpp>
 #include <Control.hpp>
-#include <EditorVCSInterface.hpp>
-#include <PanelContainer.hpp>
 #include <Directory.hpp>
+#include <EditorVCSInterface.hpp>
 #include <File.hpp>
+#include <Godot.hpp>
+#include <OS.hpp>
+#include <PanelContainer.hpp>
 
-#include <git_common.h>
 #include <allocation_defs.h>
+#include <git_common.h>
 
 #include <git2.h>
 
@@ -20,18 +21,25 @@ class GitAPI : public EditorVCSInterface {
 
 	GODOT_CLASS(GitAPI, EditorVCSInterface)
 
-	static GitAPI *singleton;
+	const int max_commit_fetch = 10;
 
 	bool is_initialized;
 	bool can_commit;
 
-	Array staged_files;
-
 	PanelContainer *init_settings_panel_container;
 	Button *init_settings_button;
 
-	git_repository *repo;
-	
+	git_repository *repo = nullptr;
+
+	const char *remote_name = "origin";
+	git_remote *remote;
+	git_remote_callbacks remote_cbs;
+
+	bool has_merge = false;
+	Array diff_contents;
+	git_oid pull_merge_oid;
+	Credentials creds;
+
 	void _commit(const String p_msg);
 	bool _is_vcs_initialized();
 	Dictionary _get_modified_files_data();
@@ -42,13 +50,19 @@ class GitAPI : public EditorVCSInterface {
 	bool _shut_down();
 	void _stage_file(const String p_file_path);
 	void _unstage_file(const String p_file_path);
+	void _discard_file(String p_file_path);
+	Array _get_previous_commits();
+	Array _get_branch_list();
+	bool _checkout_branch(String p_branch);
+	Dictionary _get_data();
+	void _fetch();
+	void _pull();
+	void _push();
+	const char *_get_current_branch_name(bool full_ref);
+	void _set_up_credentials(String p_username, String p_password);
 
 public:
 	static void _register_methods();
-
-	static GitAPI *get_singleton() { return singleton; }
-
-	Array diff_contents;
 
 	void create_gitignore_and_gitattributes();
 	bool create_initial_commit();

--- a/godot-git-plugin/src/git_common.cpp
+++ b/godot-git-plugin/src/git_common.cpp
@@ -1,27 +1,6 @@
 #include <git_api.h>
 #include <git_common.h>
 
-bool check_git2_errors(int error, godot::String message, godot::String function, godot::String file, int line) {
-
-	const git_error *lg2err;
-	godot::String lg2msg = "", lg2spacer = "";
-
-	if (!error) {
-
-		return false;
-	}
-
-	if ((lg2err = git_error_last()) != NULL && lg2err->message != NULL) {
-
-		lg2msg = godot::String(lg2err->message);
-		lg2spacer = " - ";
-	}
-
-	godot::Godot::print_error("Git API: " + message + " [" + godot::String::num_int64(error) + "] " + lg2spacer + lg2msg, function, file, line);
-
-	return true;
-}
-
 extern "C" int progress_cb(const char *str, int len, void *data) {
 	(void)data;
 	godot::Godot::print("remote: " + godot::String(str).strip_edges());

--- a/godot-git-plugin/src/git_common.cpp
+++ b/godot-git-plugin/src/git_common.cpp
@@ -87,3 +87,15 @@ extern "C" int credentials_cb(git_cred **out, const char *url, const char *usern
 
 	return git_cred_userpass_plaintext_new(out, creds->username, creds->password);
 }
+
+extern "C" int diff_hunk_cb(const git_diff_delta *delta, const git_diff_hunk *range, void *payload){
+	godot::Array *diff_hunks = (godot::Array *)payload;
+	godot::Dictionary hunk;
+	hunk["old_start"] = range->old_start;
+	hunk["old_lines"] = range->old_lines;
+	hunk["new_start"] = range->new_start;
+	hunk["new_lines"] = range->new_lines;
+	diff_hunks->push_back(hunk);
+
+	return 1;
+}

--- a/godot-git-plugin/src/git_common.cpp
+++ b/godot-git-plugin/src/git_common.cpp
@@ -29,7 +29,7 @@ extern "C" int progress_cb(const char *str, int len, void *data) {
 }
 
 extern "C" int update_cb(const char *refname, const git_oid *a, const git_oid *b, void *data) {
-	int short_commit_length = 8;
+	constexpr int short_commit_length = 8;
 	char a_str[short_commit_length + 1], b_str[short_commit_length + 1];
 	(void)data;
 

--- a/godot-git-plugin/src/git_common.cpp
+++ b/godot-git-plugin/src/git_common.cpp
@@ -29,17 +29,17 @@ extern "C" int progress_cb(const char *str, int len, void *data) {
 }
 
 extern "C" int update_cb(const char *refname, const git_oid *a, const git_oid *b, void *data) {
-	int short_commit_lenght = 8;
-	char a_str[short_commit_lenght + 1], b_str[short_commit_lenght + 1];
+	int short_commit_length = 8;
+	char a_str[short_commit_length + 1], b_str[short_commit_length + 1];
 	(void)data;
 
-	git_oid_tostr(b_str, short_commit_lenght - 1, b);
-	b_str[short_commit_lenght] = '\0';
+	git_oid_tostr(b_str, short_commit_length - 1, b);
+	b_str[short_commit_length] = '\0';
 	if (git_oid_is_zero(a)) {
 		godot::Godot::print("* [new] " + godot::String(b_str) + " " + godot::String(refname));
 	} else {
-		git_oid_nfmt(a_str, short_commit_lenght - 1, a);
-		a_str[short_commit_lenght] = '\0';
+		git_oid_nfmt(a_str, short_commit_length - 1, a);
+		a_str[short_commit_length] = '\0';
 		godot::Godot::print("[updated] " + godot::String(a_str) + "..." + godot::String(b_str) + " " + godot::String(refname));
 	}
 

--- a/godot-git-plugin/src/git_common.cpp
+++ b/godot-git-plugin/src/git_common.cpp
@@ -1,29 +1,25 @@
-#include <git_common.h>
 #include <git_api.h>
+#include <git_common.h>
 
-void check_git2_errors(int error, const char *message, const char *extra) {
+bool check_git2_errors(int error, godot::String message, godot::String function, godot::String file, int line) {
 
 	const git_error *lg2err;
-	const char *lg2msg = "", *lg2spacer = "";
+	godot::String lg2msg = "", lg2spacer = "";
 
 	if (!error) {
 
-		return;
+		return false;
 	}
 
 	if ((lg2err = git_error_last()) != NULL && lg2err->message != NULL) {
 
-		lg2msg = lg2err->message;
+		lg2msg = godot::String(lg2err->message);
 		lg2spacer = " - ";
 	}
 
-	if (extra) {
+	godot::Godot::print_error("Git API: " + message + " [" + godot::String::num_int64(error) + "] " + lg2spacer + lg2msg, function, file, line);
 
-		printf("Git API: %s '%s' [%d]%s%s\n", message, extra, error, lg2spacer, lg2msg);
-	} else {
-
-		printf("Git API: %s [%d]%s%s\n", message, error, lg2spacer, lg2msg);
-	}
+	return true;
 }
 
 extern "C" int diff_line_callback_function(const git_diff_delta *delta, const git_diff_hunk *hunk, const git_diff_line *line, void *payload) {
@@ -39,11 +35,13 @@ extern "C" int diff_line_callback_function(const git_diff_delta *delta, const gi
 
 		case GIT_DIFF_LINE_DEL_EOFNL:
 		case GIT_DIFF_LINE_DELETION:
-			prefix = "-"; break;
+			prefix = "-";
+			break;
 
 		case GIT_DIFF_LINE_ADD_EOFNL:
 		case GIT_DIFF_LINE_ADDITION:
-			prefix = "+"; break;
+			prefix = "+";
+			break;
 	}
 
 	godot::String content_str = content;
@@ -56,7 +54,74 @@ extern "C" int diff_line_callback_function(const git_diff_delta *delta, const gi
 	result["old_line_number"] = line->old_lineno;
 	result["offset"] = line->content_offset;
 
-	godot::GitAPI::get_singleton()->diff_contents.push_back(result);
+	godot::Array *diff_contents = (godot::Array *)payload;
+	diff_contents->push_back(result);
 
 	return 0;
+}
+
+extern "C" int progress_cb(const char *str, int len, void *data) {
+	(void)data;
+	godot::Godot::print("remote: " + godot::String(str).strip_edges());
+	return 0;
+}
+
+extern "C" int update_cb(const char *refname, const git_oid *a, const git_oid *b, void *data) {
+	int short_commit_lenght = 8;
+	char a_str[short_commit_lenght + 1], b_str[short_commit_lenght + 1];
+	(void)data;
+
+	git_oid_tostr(b_str, short_commit_lenght - 1, b);
+	b_str[short_commit_lenght] = '\0';
+	if (git_oid_is_zero(a)) {
+		godot::Godot::print("* [new] " + godot::String(b_str) + " " + godot::String(refname));
+	} else {
+		git_oid_nfmt(a_str, short_commit_lenght - 1, a);
+		a_str[short_commit_lenght] = '\0';
+		godot::Godot::print("[updated] " + godot::String(a_str) + "..." + godot::String(b_str) + " " + godot::String(refname));
+	}
+
+	return 0;
+}
+
+extern "C" int transfer_progress_cb(const git_indexer_progress *stats, void *payload) {
+
+	(void)payload;
+
+	if (stats->received_objects == stats->total_objects) {
+		godot::Godot::print("Resolving deltas " + godot::String::num_int64(stats->indexed_deltas) + "/" + godot::String::num_int64(stats->total_deltas));
+	} else if (stats->total_objects > 0) {
+		godot::Godot::print("Received " + godot::String::num_int64(stats->received_objects) + "/" + godot::String::num_int64(stats->total_objects) + " objects (" + godot::String::num_int64(stats->indexed_objects) + ") in " + godot::String::num_int64(static_cast<int>(stats->received_bytes)) + " bytes");
+	}
+	return 0;
+}
+
+extern "C" int fetchhead_foreach_cb(const char *ref_name, const char *remote_url, const git_oid *oid, unsigned int is_merge, void *payload) {
+	if (is_merge) {
+		git_oid_cpy((git_oid *)payload, oid);
+	}
+	return 0;
+}
+
+extern "C" int push_transfer_progress_cb(unsigned int current, unsigned int total, size_t bytes, void *payload) {
+	godot::Godot::print("Writing Objects: " + godot::String::num_int64((int)current * 100 / total) + "% (" + godot::String::num_int64((int)current) + "/" + godot::String::num_int64((int)total) + "), " + godot::String::num_int64(bytes) + " bytes, done.");
+	return 0;
+}
+
+extern "C" int push_update_reference_cb(const char *refname, const char *status, void *data) {
+	if (status == "") {
+		godot::Godot::print("[rejected] " + godot::String(refname) + " " + godot::String(status));
+	} else {
+		godot::Godot::print("[updated] " + godot::String(refname));
+	}
+	return 0;
+}
+
+extern "C" int credentials_cb(git_cred **out, const char *url, const char *username_from_url, unsigned int allowed_types, void *payload) {
+	Credentials *creds = (Credentials *)payload;
+	if (creds->username == "" || creds->password == "") {
+		return GIT_EUSER;
+	}
+
+	return git_cred_userpass_plaintext_new(out, creds->username, creds->password);
 }

--- a/godot-git-plugin/src/git_common.cpp
+++ b/godot-git-plugin/src/git_common.cpp
@@ -22,44 +22,6 @@ bool check_git2_errors(int error, godot::String message, godot::String function,
 	return true;
 }
 
-extern "C" int diff_line_callback_function(const git_diff_delta *delta, const git_diff_hunk *hunk, const git_diff_line *line, void *payload) {
-
-	// First we NULL terminate the line text incoming
-	char *content = new char[line->content_len + 1];
-	memcpy(content, line->content, line->content_len);
-	static int i = 0;
-	content[line->content_len] = '\0';
-
-	godot::String prefix = "";
-	switch (line->origin) {
-
-		case GIT_DIFF_LINE_DEL_EOFNL:
-		case GIT_DIFF_LINE_DELETION:
-			prefix = "-";
-			break;
-
-		case GIT_DIFF_LINE_ADD_EOFNL:
-		case GIT_DIFF_LINE_ADDITION:
-			prefix = "+";
-			break;
-	}
-
-	godot::String content_str = content;
-
-	godot::Dictionary result;
-	result["content"] = prefix + content_str;
-	result["status"] = prefix;
-	result["new_line_number"] = line->new_lineno;
-	result["line_count"] = line->num_lines;
-	result["old_line_number"] = line->old_lineno;
-	result["offset"] = line->content_offset;
-
-	godot::Array *diff_contents = (godot::Array *)payload;
-	diff_contents->push_back(result);
-
-	return 0;
-}
-
 extern "C" int progress_cb(const char *str, int len, void *data) {
 	(void)data;
 	godot::Godot::print("remote: " + godot::String(str).strip_edges());

--- a/godot-git-plugin/src/git_common.h
+++ b/godot-git-plugin/src/git_common.h
@@ -17,6 +17,7 @@ extern "C" int fetchhead_foreach_cb(const char *ref_name, const char *remote_url
 extern "C" int credentials_cb(git_cred **out, const char *url, const char *username_from_url, unsigned int allowed_types, void *payload);
 extern "C" int push_transfer_progress_cb(unsigned int current, unsigned int total, size_t bytes, void *payload);
 extern "C" int push_update_reference_cb(const char *refname, const char *status, void *data);
+extern "C" int diff_hunk_cb(const git_diff_delta *delta, const git_diff_hunk *range, void *payload);
 
 bool check_git2_errors(int error, godot::String message, godot::String function, godot::String file, int line);
 

--- a/godot-git-plugin/src/git_common.h
+++ b/godot-git-plugin/src/git_common.h
@@ -19,13 +19,5 @@ extern "C" int push_transfer_progress_cb(unsigned int current, unsigned int tota
 extern "C" int push_update_reference_cb(const char *refname, const char *status, void *data);
 extern "C" int diff_hunk_cb(const git_diff_delta *delta, const git_diff_hunk *range, void *payload);
 
-bool check_git2_errors(int error, godot::String message, godot::String function, godot::String file, int line);
-
-#define GIT2_CALL(function_call, m_error_msg)                                            \
-	if (check_git2_errors(function_call, m_error_msg, __FUNCTION__, __FILE__, __LINE__)) \
-		return;
-
-#define GIT2_CALL_R(function_call, m_error_msg, return_t)                                \
-	if (check_git2_errors(function_call, m_error_msg, __FUNCTION__, __FILE__, __LINE__)) \
-		return return_t;
 #endif // !GIT_COMMON_H
+

--- a/godot-git-plugin/src/git_common.h
+++ b/godot-git-plugin/src/git_common.h
@@ -5,10 +5,27 @@
 
 #include <git2.h>
 
-void check_git2_errors(int error, const char *message, const char *extra);
+struct Credentials {
+	char *username;
+	char *password;
+};
 
 extern "C" int diff_line_callback_function(const git_diff_delta *delta, const git_diff_hunk *hunk, const git_diff_line *line, void *payload);
+extern "C" int progress_cb(const char *str, int len, void *data);
+extern "C" int update_cb(const char *refname, const git_oid *a, const git_oid *b, void *data);
+extern "C" int transfer_progress_cb(const git_indexer_progress *stats, void *payload);
+extern "C" int fetchhead_foreach_cb(const char *ref_name, const char *remote_url, const git_oid *oid, unsigned int is_merge, void *payload);
+extern "C" int credentials_cb(git_cred **out, const char *url, const char *username_from_url, unsigned int allowed_types, void *payload);
+extern "C" int push_transfer_progress_cb(unsigned int current, unsigned int total, size_t bytes, void *payload);
+extern "C" int push_update_reference_cb(const char *refname, const char *status, void *data);
 
-#define GIT2_CALL(function_call, m_error_msg, m_additional_msg) check_git2_errors(function_call, m_error_msg, m_additional_msg);
+bool check_git2_errors(int error, godot::String message, godot::String function, godot::String file, int line);
 
+#define GIT2_CALL(function_call, m_error_msg)                                            \
+	if (check_git2_errors(function_call, m_error_msg, __FUNCTION__, __FILE__, __LINE__)) \
+		return;
+
+#define GIT2_CALL_R(function_call, m_error_msg, return_t)                                \
+	if (check_git2_errors(function_call, m_error_msg, __FUNCTION__, __FILE__, __LINE__)) \
+		return return_t;
 #endif // !GIT_COMMON_H

--- a/godot-git-plugin/src/git_common.h
+++ b/godot-git-plugin/src/git_common.h
@@ -10,7 +10,6 @@ struct Credentials {
 	char *password;
 };
 
-extern "C" int diff_line_callback_function(const git_diff_delta *delta, const git_diff_hunk *hunk, const git_diff_line *line, void *payload);
 extern "C" int progress_cb(const char *str, int len, void *data);
 extern "C" int update_cb(const char *refname, const git_oid *a, const git_oid *b, void *data);
 extern "C" int transfer_progress_cb(const git_indexer_progress *stats, void *payload);

--- a/godot-git-plugin/thirdparty/libgit2/CMakeLists.txt
+++ b/godot-git-plugin/thirdparty/libgit2/CMakeLists.txt
@@ -41,9 +41,9 @@ INCLUDE(IdeSplitSources)
 INCLUDE(FeatureSummary)
 INCLUDE(EnableWarnings)
 
-# Build options
-#
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Build options
 OPTION(SONAME				"Set the (SO)VERSION of the target"			 ON)
 OPTION(BUILD_SHARED_LIBS		"Build Shared Library (OFF for Static)"			 ON)
 OPTION(THREADSAFE			"Build libgit2 as threadsafe"				 ON)


### PR DESCRIPTION
It is based on libgit2-bump-fix and requires [vcs-new-ui](https://github.com/Janglee123/godot/tree/vcs-new-ui) to work. Both branches are updated parallelly. 