### PR TITLE
Port build scripts to Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ api.json
 # VSCode Cache
 .vscode/
 
+# Mac stuff
+.DS_Store
+
 # Binaries
 bin/
 intermediate/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Git implementation of the Godot Engine VCS interface in Godot. We use [libgit2](
 
 ## Installation Instructions
 
- 1. Grab the Linux and/or Windows binaries here: <https://github.com/godotengine/godot-git-plugin/releases>
+ 1. Grab the platform binaries here: <https://github.com/godotengine/godot-git-plugin/releases>
  2. Then read the installation instructions: https://github.com/godotengine/godot-git-plugin/wiki
 
 ## Build Instructions
@@ -33,6 +33,14 @@ Required build tools:
 1. Prepare script for execution: ```chmod 755 build_libs.sh```
 2. Run ```. ./build_libs.sh Release```.
 3. Run ```scons platform=x11 target=release```.
+
+### MacOS
+
+> G++ and Clang++ are our recommended compilers for MacOS
+
+1. Prepare script for execution: ```chmod 755 build_libs_mac.sh```
+2. Run ```. ./build_libs_mac.sh Release```.
+3. Run ```scons platform=osx target=release```.
 
 #### Debug build
 

--- a/build_libs_mac.sh
+++ b/build_libs_mac.sh
@@ -1,0 +1,23 @@
+git submodule init;
+git submodule update --init --recursive;
+
+cd godot-git-plugin/thirdparty/libgit2/
+mkdir build
+cd build/
+rm CMakeCache.txt
+cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_CLAR=OFF -DBUILD_EXAMPLES=OFF -DUSE_SSH=OFF -DUSE_HTTPS=OFF -DUSE_BUNDLED_ZLIB=ON -DUSE_ICONV=OFF
+cmake --build . --config $1
+cd ../../../../
+mkdir -p "demo/bin/osx/"
+cp "godot-git-plugin/thirdparty/libgit2/build/libgit2.a" "demo/bin/osx/libgit2.a"
+
+if [ -z "$CI" ]
+then
+	echo "Non-CI run was detected"     
+else
+	echo "CI run was detected"
+fi
+
+cd godot-cpp/;
+scons platform=osx target=$1 generate_bindings=yes bits=64;
+cd ..

--- a/demo/git_api.gdnlib
+++ b/demo/git_api.gdnlib
@@ -7,10 +7,12 @@ reloadable=false
 
 [entry]
 
+OSX.64="res://bin/osx/release/libgitapi.dylib"
 Windows.64="res://bin/win64/release/libgitapi.dll"
 X11.64="res://bin/x11/release/libgitapi.so"
 
 [dependencies]
 
+OSX.64=[  ]
 Windows.64=[  ]
 X11.64=[  ]


### PR DESCRIPTION
Had to disable iconv encoding conversion because Mac seemed to have problems with detecting the correct version (FreeBSD one or the GNU one)