### PR TITLE
Add comment in README on nature of master targeting upcoming Godot

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Git implementation of the Godot Engine VCS interface in Godot. We use [libgit2](https://libgit2.org) as our backend to simulate Git in code.
 
-> Planned for Godot 4.0 since Godot 3.2+. Look for other branches for support in other Godot releases.
+> Planned for the upcoming version of Godot. Look for other branches for support in other Godot releases.
 
 ## Installation Instructions
 


### PR DESCRIPTION
This solidifies that master is always the leading branch which most often during development will depend on an unreleased Godot version (basically whatever latest version GDNative can provide as of date).