### PR TITLE
linux build script updated to be compatible with other shells

### DIFF
--- a/build_libs.sh
+++ b/build_libs.sh
@@ -19,6 +19,6 @@ else
 fi
 
 cd godot-cpp/;
-CORES=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu)
+CORES=$(grep -c \^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu)
 scons platform=linux target=$1 generate_bindings=yes bits=64 -j$CORES;
 cd ..


### PR DESCRIPTION
CORES variable assignment wouldn't work with shell other than bash.
I've fixed the variable assignment to be compatible with all shells. Bash behaviour remain unchanged.