### PR TITLE
Fix pcre not being included in static libgit2 build

### DIFF
--- a/build_libs.sh
+++ b/build_libs.sh
@@ -5,7 +5,7 @@ cd godot-git-plugin/thirdparty/libgit2/
 mkdir build
 cd build/
 rm -f CMakeCache.txt
-cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_CLAR=OFF -DBUILD_EXAMPLES=OFF -DUSE_SSH=OFF -DUSE_HTTPS=OFF -DUSE_BUNDLED_ZLIB=ON
+cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_CLAR=OFF -DBUILD_EXAMPLES=OFF -DUSE_SSH=OFF -DUSE_HTTPS=OFF -DUSE_BUNDLED_ZLIB=ON -DREGEX_BACKEND=builtin
 cmake --build . --config $1
 cd ../../../../
 mkdir -p "demo/addons/godot-git-plugin/x11/"


### PR DESCRIPTION
Fixes #94

This backports a fix from v2.x which adds the builtin version of pcre as a static dependency, rather than relying on the OS to provide pcre.