### PR TITLE
Update libssh2

### DIFF
--- a/thirdparty/ssh2/SCsub
+++ b/thirdparty/ssh2/SCsub
@@ -31,6 +31,7 @@ libssh2_sources = [
     "libssh2/src/misc.c",
     "libssh2/src/pem.c",
     "libssh2/src/session.c",
+    "libssh2/src/userauth_kbd_packet.c",
     "libssh2/src/userauth.c",
 ]
 


### PR DESCRIPTION
Updates the libssh2 submodule to the latest commit available.

This resolved #145 for me on Windows.