### PR TITLE
Address issue #172, to use public key path if present in preference to using password.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   linux-x64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: build-linux-editor-x64

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,6 +5,7 @@
 [submodule "libgit2"]
 	path = thirdparty/git2/libgit2
 	url = https://github.com/libgit2/libgit2
+	ignore = untracked
 [submodule "thirdparty/ssh2/libssh2"]
 	path = thirdparty/ssh2/libssh2
 	url = https://github.com/libssh2/libssh2

--- a/godot-git-plugin/src/git_callbacks.cpp
+++ b/godot-git-plugin/src/git_callbacks.cpp
@@ -96,7 +96,6 @@ extern "C" int credentials_cb(git_cred **out, const char *url, const char *usern
 		return git_cred_userpass_plaintext_new(out, CString(proper_username).data, CString(creds->password).data);
 	}
 
-
 	if (allowed_types & GIT_CREDENTIAL_USERNAME) {
 		return git_credential_username_new(out, CString(proper_username).data);
 	}

--- a/godot-git-plugin/src/git_callbacks.cpp
+++ b/godot-git-plugin/src/git_callbacks.cpp
@@ -82,17 +82,20 @@ extern "C" int credentials_cb(git_cred **out, const char *url, const char *usern
 
 	godot::String proper_username = username_from_url ? username_from_url : creds->username;
 
+	if (!creds->ssh_public_key_path.is_empty()) {
+		if (allowed_types & GIT_CREDENTIAL_SSH_KEY) {
+			return git_credential_ssh_key_new(out,
+					CString(proper_username).data,
+					CString(creds->ssh_public_key_path).data,
+					CString(creds->ssh_private_key_path).data,
+					CString(creds->ssh_passphrase).data);
+		}
+	}
+
 	if (allowed_types & GIT_CREDENTIAL_USERPASS_PLAINTEXT) {
 		return git_cred_userpass_plaintext_new(out, CString(proper_username).data, CString(creds->password).data);
 	}
 
-	if (allowed_types & GIT_CREDENTIAL_SSH_KEY) {
-		return git_credential_ssh_key_new(out,
-				CString(proper_username).data,
-				CString(creds->ssh_public_key_path).data,
-				CString(creds->ssh_private_key_path).data,
-				CString(creds->ssh_passphrase).data);
-	}
 
 	if (allowed_types & GIT_CREDENTIAL_USERNAME) {
 		return git_credential_username_new(out, CString(proper_username).data);


### PR DESCRIPTION
This fix simply changes the use of SSH credentials to be conditional based on the presence of SSH credentials in the Credentials object. 

This lets the user specify the presence of SSH credentials if that is the desired method, or the password if that is the desired method.  I tested against a repository that used SSH credentials and one that used a password.  

The third method was a bit of a mystery to me, so I didn't test that option.  I also do not have a Windows or Mac environment to test this in (only tested in Linux), but with only this small change it is hard to imagine what could be different.