### PR TITLE
fix a comparision bug with renamed git statuses

### DIFF
--- a/godot-git-plugin/src/git_plugin.cpp
+++ b/godot-git-plugin/src/git_plugin.cpp
@@ -245,7 +245,7 @@ godot::TypedArray<godot::Dictionary> GitPlugin::_get_modified_files_data() {
 		}
 
 		if (entry->status & git_status_index) {
-			if (entry->status == GIT_STATUS_INDEX_RENAMED) {
+			if (entry->status & GIT_STATUS_INDEX_RENAMED) {
 				godot::String old_path = entry->head_to_index->old_file.path;
 				stats_files.push_back(create_status_file(old_path, map_changes.at(GIT_STATUS_INDEX_DELETED), TREE_AREA_STAGED));
 				stats_files.push_back(create_status_file(path, map_changes.at(GIT_STATUS_INDEX_NEW), TREE_AREA_STAGED));


### PR DESCRIPTION
there is a bug where if you have a entry->status with GIT_STATUS_INDEX_RENAMED but with another flag like GIT_STATUS_INDEX_MODIFIED, godot-git-plugin will crash godot entirely with a c++ out of range exception as it cant find the proper mapped value for 2 flags. so i changed it to do a logical and so it can execute the proper renamed logic.