### PR TITLE
Updates for issue #150 to use UTF8 instead of String when dealing with data from the git repository

### DIFF
--- a/godot-git-plugin/src/git_callbacks.cpp
+++ b/godot-git-plugin/src/git_callbacks.cpp
@@ -13,7 +13,7 @@ extern "C" int progress_cb(const char *str, int len, void *data) {
 	char *progress_str = new char[len + 1];
 	std::memcpy(progress_str, str, len);
 	progress_str[len] = '\0';
-	godot::UtilityFunctions::push_warning("remote: ", CString(godot::String(progress_str).strip_edges()).data);
+	godot::UtilityFunctions::push_warning("remote: ", godot::String::utf8(progress_str).strip_edges());
 	delete[] progress_str;
 
 	return 0;
@@ -27,10 +27,10 @@ extern "C" int update_cb(const char *refname, const git_oid *a, const git_oid *b
 
 	git_oid_tostr(b_str, short_commit_length, b);
 	if (git_oid_is_zero(a)) {
-		godot::UtilityFunctions::print("* [new] ", CString(godot::String(b_str)).data, " ", CString(godot::String(refname)).data);
+		godot::UtilityFunctions::print("* [new] ", godot::String::utf8(b_str), " ", godot::String::utf8(refname));
 	} else {
 		git_oid_tostr(a_str, short_commit_length, a);
-		godot::UtilityFunctions::print("[updated] ", CString(godot::String(a_str)).data, "...", CString(godot::String(b_str)).data, " ", CString(godot::String(refname)).data);
+		godot::UtilityFunctions::print("[updated] ", godot::String::utf8(a_str), "...", godot::String::utf8(b_str), " ", godot::String::utf8(refname));
 	}
 
 	return 0;
@@ -68,11 +68,11 @@ extern "C" int push_transfer_progress_cb(unsigned int current, unsigned int tota
 }
 
 extern "C" int push_update_reference_cb(const char *refname, const char *status, void *data) {
-	godot::String status_str = status;
-	if (status_str == "") {
-		godot::UtilityFunctions::print("[rejected] ", CString(godot::String(refname)).data, " ", CString(status_str).data);
+	if (status != NULL) {
+		godot::String status_str = godot::String::utf8(status);
+		godot::UtilityFunctions::print("[rejected] ", godot::String::utf8(refname), " ", status_str);
 	} else {
-		godot::UtilityFunctions::print("[updated] ", CString(godot::String(refname)).data);
+		godot::UtilityFunctions::print("[updated] ", godot::String::utf8(refname));
 	}
 	return 0;
 }

--- a/godot-git-plugin/src/git_plugin.cpp
+++ b/godot-git-plugin/src/git_plugin.cpp
@@ -66,7 +66,7 @@ bool GitPlugin::check_errors(int error, godot::String function, godot::String fi
 		message = message + godot::String::utf8(lg2err->message);
 	}
 
-	godot::UtilityFunctions::push_error("GitPlugin: ", CString(message).data, " in ", CString(file).data, ":", CString(function).data, "#L", line);
+	godot::UtilityFunctions::push_error("GitPlugin: ", message, " in ", file, ":", function, "#L", line);
 	return true;
 }
 
@@ -246,7 +246,7 @@ godot::TypedArray<godot::Dictionary> GitPlugin::_get_modified_files_data() {
 
 		if (entry->status & git_status_index) {
 			if (entry->status & GIT_STATUS_INDEX_RENAMED) {
-				godot::String old_path = entry->head_to_index->old_file.path;
+				godot::String old_path = godot::String::utf8(entry->head_to_index->old_file.path);
 				stats_files.push_back(create_status_file(old_path, map_changes.at(GIT_STATUS_INDEX_DELETED), TREE_AREA_STAGED));
 				stats_files.push_back(create_status_file(path, map_changes.at(GIT_STATUS_INDEX_NEW), TREE_AREA_STAGED));
 			} else {
@@ -273,9 +273,9 @@ godot::TypedArray<godot::String> GitPlugin::_get_branch_list() {
 
 		if (git_branch_is_head(ref.get())) {
 			// Always send the current branch as the first branch in list
-			branch_names.push_front(name);
+			branch_names.push_front(godot::String::utf8(name));
 		} else {
-			branch_names.push_back(godot::String(name));
+			branch_names.push_back(godot::String::utf8(name));
 		}
 	}
 
@@ -352,7 +352,7 @@ godot::String GitPlugin::_get_current_branch_name() {
 	const char *name = "";
 	GIT2_CALL_R(git_branch_name(&name, branch.get()), "Could not get branch name from current branch reference", "");
 
-	return name;
+	return godot::String::utf8(name);
 }
 
 godot::TypedArray<godot::String> GitPlugin::_get_remotes() {
@@ -361,7 +361,7 @@ godot::TypedArray<godot::String> GitPlugin::_get_remotes() {
 
 	godot::TypedArray<godot::String> remotes;
 	for (int i = 0; i < remote_array.count; i++) {
-		remotes.push_back(remote_array.strings[i]);
+		remotes.push_back(godot::String::utf8(remote_array.strings[i]));
 	}
 
 	return remotes;
@@ -385,7 +385,7 @@ godot::TypedArray<godot::Dictionary> GitPlugin::_get_previous_commits(int32_t ma
 		godot::String msg = godot::String::utf8(git_commit_message(commit.get()));
 
 		const git_signature *sig = git_commit_author(commit.get());
-		godot::String author = godot::String() + sig->name + " <" + sig->email + ">";
+		godot::String author = godot::String::utf8(sig->name) + " <" + godot::String::utf8(sig->email) + ">";
 
 		commits.push_back(create_commit(msg, author, commit_id, sig->when.time, sig->when.offset));
 	}
@@ -394,7 +394,7 @@ godot::TypedArray<godot::Dictionary> GitPlugin::_get_previous_commits(int32_t ma
 }
 
 void GitPlugin::_fetch(const godot::String &remote) {
-	godot::UtilityFunctions::print("GitPlugin: Performing fetch from ", CString(remote).data);
+	godot::UtilityFunctions::print("GitPlugin: Performing fetch from ", remote);
 
 	git_remote_ptr remote_object;
 	GIT2_CALL(git_remote_lookup(Capture(remote_object), repo.get(), CString(remote).data), "Could not lookup remote \"" + remote + "\"");
@@ -418,7 +418,7 @@ void GitPlugin::_fetch(const godot::String &remote) {
 }
 
 void GitPlugin::_pull(const godot::String &remote) {
-	godot::UtilityFunctions::print("GitPlugin: Performing pull from ", CString(remote).data);
+	godot::UtilityFunctions::print("GitPlugin: Performing pull from ", remote);
 
 	git_remote_ptr remote_object;
 	GIT2_CALL(git_remote_lookup(Capture(remote_object), repo.get(), CString(remote).data), "Could not lookup remote \"" + remote + "\"");
@@ -515,7 +515,7 @@ void GitPlugin::_pull(const godot::String &remote) {
 }
 
 void GitPlugin::_push(const godot::String &remote, bool force) {
-	godot::UtilityFunctions::print("GitPlugin: Performing push to ", CString(remote).data);
+	godot::UtilityFunctions::print("GitPlugin: Performing push to ", remote);
 
 	git_remote_ptr remote_object;
 	GIT2_CALL(git_remote_lookup(Capture(remote_object), repo.get(), CString(remote).data), "Could not lookup remote \"" + remote + "\"");
@@ -529,7 +529,8 @@ void GitPlugin::_push(const godot::String &remote, bool force) {
 	remote_cbs.push_transfer_progress = &push_transfer_progress_cb;
 	remote_cbs.push_update_reference = &push_update_reference_cb;
 
-	GIT2_CALL(git_remote_connect(remote_object.get(), GIT_DIRECTION_PUSH, &remote_cbs, nullptr, nullptr), "Could not connect to remote \"" + remote + "\". Are your credentials correct? Try using a PAT token (in case you are using Github) as your password");
+	godot::String msg = "Could not connect to remote \"" + remote + "\". Are your credentials correct? Try using a PAT token (in case you are using Github) as your password";
+	GIT2_CALL(git_remote_connect(remote_object.get(), GIT_DIRECTION_PUSH, &remote_cbs, nullptr, nullptr), msg);
 
 	godot::String branch_name = _get_current_branch_name();
 
@@ -682,7 +683,7 @@ bool GitPlugin::_initialize(const godot::String &project_path) {
 	if (git_repository_discover(&discovered_repo_path, CString(project_path).data, 1, nullptr) == 0) {
 		repo_project_path = godot::String::utf8(discovered_repo_path.ptr);
 
-		godot::UtilityFunctions::print("Found a repository at " + godot::String::utf8(discovered_repo_path.ptr) + ".");
+		godot::UtilityFunctions::print("Found a repository at " + repo_project_path + ".");
 		git_buf_dispose(&discovered_repo_path);
 	} else {
 		repo_project_path = project_path;
@@ -690,7 +691,7 @@ bool GitPlugin::_initialize(const godot::String &project_path) {
 		godot::UtilityFunctions::push_warning("Could not find any higher level repositories.");
 	}
 
-	godot::UtilityFunctions::print("Selected repository path: " + godot::String(repo_project_path) + ".");
+	godot::UtilityFunctions::print("Selected repository path: " + repo_project_path + ".");
 	GIT2_CALL_R(git_repository_init(Capture(repo), CString(repo_project_path).data, 0), "Could not initialize repository", false);
 
 	git_reference_ptr head;


### PR DESCRIPTION
Re-implemented the original update for UTF-8 based on latest master, for a clean merge.

Replaced the places where the libgit2 API used godot::String with godot::String::utf8

Tested using emojis as place holders for language specific Unicode characters
- in file names and directory names. 
- renames of files
- commit messages

___

- *Production edit: This closes https://github.com/godotengine/godot-git-plugin/issues/150.*