### PR TITLE
GitHub Actions: Update Windows and macOS runners to their latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
             demo/
 
   windows-x64:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v3
         with:
@@ -59,7 +59,7 @@ jobs:
             demo/
 
   macos-universal:
-    runs-on: macos-11
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
The Linux runner remains on Ubuntu 20.04 to ensure compiled builds are compatible with as many distributions as possible.
