### PR TITLE
Properly specify the `STATIC_CRT` libgit2 flag

### DIFF
--- a/tools/git2.py
+++ b/tools/git2.py
@@ -26,7 +26,7 @@ def build_library(env, deps):
         "LIBSSH2_INCLUDE_DIR": env.Dir("#thirdparty/ssh2/libssh2/include").abspath,
         "LIBSSH2_LIBRARY": deps[-1],
         "USE_WINHTTP": 0,
-        "STATIC_CRT": 0,
+        "STATIC_CRT": env.get("use_static_cpp", True),
     }
 
     if env["platform"] != "windows":


### PR DESCRIPTION
libgit2 CMake configuration uses a custom flag `STATIC_CRT` and not the new CMake policy CMP0091.

When forcing the CMake policy (as we do in our cmake tool), we need to also set the custom `STATIC_CRT` to avoid compiler warning about the /MD and /MT flag being overridden.

This was probably set to `0` because the old godot cpp used /MD by default.

Follow up on https://github.com/godotengine/godot-git-plugin/pull/199#issuecomment-2911619026