### PR TITLE
Force macOS deployment target for OpenSSL when specified

### DIFF
--- a/tools/openssl.py
+++ b/tools/openssl.py
@@ -80,6 +80,8 @@ def ssl_platform_flags(env):
             api = int(env["android_api_level"])
             args.append("-D__ANDROID_API__=%s" % api)
     elif env["platform"] == "macos":
+        if env["macos_deployment_target"] != "default":
+            args.append("-mmacosx-version-min=%s" % env["macos_deployment_target"])
         # OSXCross toolchain setup.
         if sys.platform != "darwin" and "OSXCROSS_ROOT" in os.environ:
             for k in ["CC", "CXX", "AR", "AS", "RANLIB"]:


### PR DESCRIPTION
Fixes:
```
ld: warning: object file (...) was built for newer 'macOS' version (15.0) than being linked (11.0)
```