### PR TITLE
ssh2/libgit2: Disable openssl and zlib detection

### DIFF
--- a/tools/git2.py
+++ b/tools/git2.py
@@ -27,6 +27,8 @@ def build_library(env, deps):
         "LIBSSH2_LIBRARY": deps[-1],
         "USE_WINHTTP": 0,
         "STATIC_CRT": env.get("use_static_cpp", True),
+        "CMAKE_DISABLE_FIND_PACKAGE_ZLIB": 1,
+        "CMAKE_DISABLE_FIND_PACKAGE_OPENSSL": 1,
     }
 
     if env["platform"] != "windows":

--- a/tools/ssh2.py
+++ b/tools/ssh2.py
@@ -12,6 +12,8 @@ def build_library(env, deps):
         "BUILD_EXAMPLES": 0,
         "BUILD_TESTING": 0,
         "BUILD_SHARED_LIBS": 0,
+        "CMAKE_DISABLE_FIND_PACKAGE_ZLIB": 1,
+        "CMAKE_DISABLE_FIND_PACKAGE_OPENSSL": 1,
         "CRYPTO_BACKEND": "OpenSSL",
     }
 


### PR DESCRIPTION
This seems to only be used with the OpenSSL backend (which we plan to drop).

libgit2 already use builtin ZLIB, I'm not even sure we if it would be used in libssh2 (we only use libssh2 to provide git ssh access, and git already compress objects.

Should fix the Fedora issue reported in https://github.com/godotengine/godot-git-plugin/pull/199#issuecomment-2914277066 .