### PR TITLE
Add CA certificate bundle path override for SSL issues

### DIFF
--- a/addons/godot-git-plugin/ca_cert_config.txt
+++ b/addons/godot-git-plugin/ca_cert_config.txt
@@ -1,5 +1,17 @@
 # CA Certificate Bundle Configuration for godot-git-plugin
-# Uncomment the line that matches your system
+# 
+# This file allows you to specify a custom CA certificate bundle path
+# to resolve SSL certificate validation errors on all platforms.
+#
+# INSTRUCTIONS:
+# 1. Uncomment the line that matches your system
+# 2. Adjust the path if your certificates are located elsewhere
+# 3. Restart Godot after making changes
+
+#
+# ============================================================
+# LINUX - Common certificate bundle locations:
+# ============================================================
 
 # Linux (Debian/Ubuntu/Mint)
 #/etc/ssl/certs/ca-certificates.crt
@@ -10,6 +22,13 @@
 # Linux (OpenSUSE)
 # /etc/ssl/ca-bundle.pem
 
+# Custom path
+# /path/to/your/ca-bundle.crt
+
+# ============================================================
+# MACOS - Common certificate bundle locations:
+# ============================================================
+
 # macOS (Homebrew OpenSSL)
 # /usr/local/etc/openssl@3/cert.pem
 
@@ -18,3 +37,17 @@
 
 # Custom path
 # /path/to/your/ca-bundle.crt
+
+# ============================================================
+# WINDOWS - Common certificate bundle locations:
+# ============================================================
+
+# Use forward slashes (/) in paths, even on Windows
+# Git backend selection during installation doesn't affect this plugin
+# Git for Windows (works with both OpenSSL and Secure Channel installations)
+# Possible Windows Paths for cert included with Git
+# C:/Program Files/Git/mingw64/etc/ssl/certs/ca-bundle.crt
+# C:/Program Files/Git/usr/ssl/certs/ca-bundle.crt
+
+# Custom path
+# C:/path/to/your/ca-bundle.crt

--- a/addons/godot-git-plugin/ca_cert_config.txt
+++ b/addons/godot-git-plugin/ca_cert_config.txt
@@ -1,0 +1,20 @@
+# CA Certificate Bundle Configuration for godot-git-plugin
+# Uncomment the line that matches your system
+
+# Linux (Debian/Ubuntu/Mint)
+#/etc/ssl/certs/ca-certificates.crt
+
+# Linux (RHEL/CentOS/Fedora)
+# /etc/pki/tls/certs/ca-bundle.crt
+
+# Linux (OpenSUSE)
+# /etc/ssl/ca-bundle.pem
+
+# macOS (Homebrew OpenSSL)
+# /usr/local/etc/openssl@3/cert.pem
+
+# macOS (System)
+# /etc/ssl/cert.pem
+
+# Custom path
+# /path/to/your/ca-bundle.crt

--- a/godot-git-plugin/src/git_plugin.cpp
+++ b/godot-git-plugin/src/git_plugin.cpp
@@ -30,7 +30,7 @@
 #define COMMA ,
 
 godot::String get_plugin_base_path() {
-    return "res://addons/godot-git-plugin/";
+	return "res://addons/godot-git-plugin/";
 }
 
 void GitPlugin::_bind_methods() {
@@ -44,10 +44,10 @@ void GitPlugin::_set_ca_bundle_path(const godot::String &path) {
 	if (!ca_bundle_path.is_empty()) {
 		// Convert to C string
 		std::string path_str = std::string(path.utf8().get_data());
-		
+
 		// Tell libgit2 to use this certificate file
 		int error = git_libgit2_opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, path_str.c_str(), NULL);
-		
+
 		if (error == 0) {
 			godot::UtilityFunctions::print("GitPlugin: CA bundle set to ", ca_bundle_path);
 		} else {
@@ -727,24 +727,23 @@ bool GitPlugin::_initialize(const godot::String &project_path) {
 		create_gitignore_and_gitattributes();
 	}
 
-
-    godot::String config_path = "res://addons/godot-git-plugin/ca_cert_config.txt";
-    if (godot::FileAccess::file_exists(config_path)) {
-        godot::UtilityFunctions::print("GitPlugin: file_exists ",config_path);
-        godot::Ref<godot::FileAccess> file =
-            godot::FileAccess::open(config_path, godot::FileAccess::READ);
-        if (file.is_valid()) {
-            while (!file->eof_reached()) {
-                godot::String line = file->get_line().strip_edges();
-                if (line.is_empty() || line.begins_with("#")) {
-                    continue;
-                }
-                _set_ca_bundle_path(line);
-                break;
-            }
-            file->close();
-        }
-    }
+	godot::String config_path = "res://addons/godot-git-plugin/ca_cert_config.txt";
+	if (godot::FileAccess::file_exists(config_path)) {
+		godot::UtilityFunctions::print("GitPlugin: file_exists ", config_path);
+		godot::Ref<godot::FileAccess> file =
+				godot::FileAccess::open(config_path, godot::FileAccess::READ);
+		if (file.is_valid()) {
+			while (!file->eof_reached()) {
+				godot::String line = file->get_line().strip_edges();
+				if (line.is_empty() || line.begins_with("#")) {
+					continue;
+				}
+				_set_ca_bundle_path(line);
+				break;
+			}
+			file->close();
+		}
+	}
 
 	return true;
 }

--- a/godot-git-plugin/src/git_plugin.cpp
+++ b/godot-git-plugin/src/git_plugin.cpp
@@ -29,8 +29,34 @@
 
 #define COMMA ,
 
+godot::String get_plugin_base_path() {
+    return "res://addons/godot-git-plugin/";
+}
+
 void GitPlugin::_bind_methods() {
-	// Doesn't seem to require binding functions for now
+	godot::ClassDB::bind_method(godot::D_METHOD("set_ca_bundle_path", "path"), &GitPlugin::_set_ca_bundle_path);
+}
+
+void GitPlugin::_set_ca_bundle_path(const godot::String &path) {
+	// Store path for later use. If empty, default runtime behavior remains unchanged.
+	ca_bundle_path = path;
+
+	if (!ca_bundle_path.is_empty()) {
+		// Convert to C string
+		std::string path_str = std::string(path.utf8().get_data());
+		
+		// Tell libgit2 to use this certificate file
+		int error = git_libgit2_opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, path_str.c_str(), NULL);
+		
+		if (error == 0) {
+			godot::UtilityFunctions::print("GitPlugin: CA bundle set to ", ca_bundle_path);
+		} else {
+			const git_error *e = git_error_last();
+			godot::UtilityFunctions::print("GitPlugin: Failed to set CA bundle: ", e ? e->message : "unknown error");
+		}
+	} else {
+		godot::UtilityFunctions::print("GitPlugin: CA bundle cleared");
+	}
 }
 
 GitPlugin::GitPlugin() {
@@ -700,6 +726,25 @@ bool GitPlugin::_initialize(const godot::String &project_path) {
 	if (!head) {
 		create_gitignore_and_gitattributes();
 	}
+
+
+    godot::String config_path = "res://addons/godot-git-plugin/ca_cert_config.txt";
+    if (godot::FileAccess::file_exists(config_path)) {
+        godot::UtilityFunctions::print("GitPlugin: file_exists ",config_path);
+        godot::Ref<godot::FileAccess> file =
+            godot::FileAccess::open(config_path, godot::FileAccess::READ);
+        if (file.is_valid()) {
+            while (!file->eof_reached()) {
+                godot::String line = file->get_line().strip_edges();
+                if (line.is_empty() || line.begins_with("#")) {
+                    continue;
+                }
+                _set_ca_bundle_path(line);
+                break;
+            }
+            file->close();
+        }
+    }
 
 	return true;
 }

--- a/godot-git-plugin/src/git_plugin.cpp
+++ b/godot-git-plugin/src/git_plugin.cpp
@@ -42,14 +42,17 @@ void GitPlugin::_set_ca_bundle_path(const godot::String &path) {
 	ca_bundle_path = path;
 
 	if (!ca_bundle_path.is_empty()) {
+		// Normalize path (convert backslashes to forward slashes)
+		godot::String normalized_path = ca_bundle_path.replace("\\", "/");
+
 		// Convert to C string
-		std::string path_str = std::string(path.utf8().get_data());
+		std::string path_str = std::string(normalized_path.utf8().get_data());
 
 		// Tell libgit2 to use this certificate file
 		int error = git_libgit2_opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, path_str.c_str(), NULL);
 
 		if (error == 0) {
-			godot::UtilityFunctions::print("GitPlugin: CA bundle set to ", ca_bundle_path);
+			godot::UtilityFunctions::print("GitPlugin: CA bundle set to ", normalized_path);
 		} else {
 			const git_error *e = git_error_last();
 			godot::UtilityFunctions::print("GitPlugin: Failed to set CA bundle: ", e ? e->message : "unknown error");

--- a/godot-git-plugin/src/git_plugin.h
+++ b/godot-git-plugin/src/git_plugin.h
@@ -29,7 +29,8 @@ public:
 	git_oid pull_merge_oid = {};
 	godot::String repo_project_path;
 	std::unordered_map<git_status_t, ChangeType> map_changes;
-
+	godot::String ca_bundle_path;
+    
 	GitPlugin();
 
 	// Endpoints
@@ -56,6 +57,7 @@ public:
 	void _push(const godot::String &remote, bool force) override;
 	void _fetch(const godot::String &remote) override;
 	godot::TypedArray<godot::Dictionary> _get_line_diff(const godot::String &file_path, const godot::String &text) override;
+	void _set_ca_bundle_path(const godot::String &path);
 
 	// Helpers
 	godot::TypedArray<godot::Dictionary> _parse_diff(git_diff *p_diff);

--- a/godot-git-plugin/src/git_plugin.h
+++ b/godot-git-plugin/src/git_plugin.h
@@ -30,7 +30,7 @@ public:
 	godot::String repo_project_path;
 	std::unordered_map<git_status_t, ChangeType> map_changes;
 	godot::String ca_bundle_path;
-    
+
 	GitPlugin();
 
 	// Endpoints


### PR DESCRIPTION
## Description
Adds support for custom CA certificate bundle path configuration to resolve SSL certificate validation failures.

## Fixes
#146

## Affected Platforms
This issue affects **all platforms** (Linux, Windows, macOS), not just Linux:
- **Linux**: Confirmed on Ubuntu 24.04 / Pop!_OS 24.04 (tested by me)
- **Windows**: Confirmed on Windows 10 (tested by me)
- **macOS**: Likely affected (same root cause)

The plugin appears to be built with OpenSSL on all platforms, which fails to locate system CA certificates without proper configuration.

## Testing
- ✅ Tested and working on Linux (Ubuntu 24.04, Pop!_OS 24.04) with Godot 4.5.1 and 4.6
- ✅ Tested and working on Windows 10 VM with Godot 4.6

## Changes
- Added `ca_bundle_path` member and `set_ca_bundle_path()` method to GitPlugin
- Implemented automatic config loading from `ca_cert_config.txt`
- Uses `git_libgit2_opts(GIT_OPT_SET_SSL_CERT_LOCATIONS)` for runtime certificate configuration
- Included template config file with examples for common Linux distributions

## Testing
Tested on Linux with custom CA bundle path. SSL operations (fetch/pull/push) now work correctly when config file is present.

## Behavior
- **Opt-in**: No changes to default behavior
- **Zero impact**: Users without the config file experience no changes
- **User-friendly**: Simple text file configuration, no code modifications needed

## Example Config File
```txt
# ca_cert_config.txt
/etc/ssl/certs/ca-certificates.crt
```

## Rationale
While ideally libgit2 would auto-detect certificate locations on all systems, this provides users immediate control in environments where auto-detection fails. This follows the same pattern as curl's `--cacert` and git's `http.sslCAInfo` options.