### PR TITLE
Update libgit2 to 1.9.2

### DIFF
--- a/tools/git2.py
+++ b/tools/git2.py
@@ -13,7 +13,7 @@ def build_library(env, deps):
         "BUILD_CLI": 0,
         "BUILD_EXAMPLES": 0,
         "BUILD_FUZZERS": 0,
-        "USE_SSH": 1,
+        "USE_SSH": "ON",
         "USE_HTTPS": 1,
         "USE_SHA1": 1,
         "USE_BUNDLED_ZLIB": 1,


### PR DESCRIPTION
This PR updates libgit2 to version 1.9.2. Version 1.7.0 (the one used previously) was no longer compatible with the newest versions of macOS due to usage of an outdated zlib library inside of libgit2.

A similar problem can be seen in this issue: https://github.com/bulletphysics/bullet3/issues/4607

<img width="1725" height="315" alt="image" src="https://github.com/user-attachments/assets/a9569f8b-6841-406b-9916-2c51b73f9e26" />
